### PR TITLE
[ai-assisted] fix(cache): prevent topic post list cache ClassCastException

### DIFF
--- a/starter/build.gradle.kts
+++ b/starter/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok:$lombokVersion")
 	testCompileOnly("org.projectlombok:lombok:$lombokVersion")
     testAnnotationProcessor("org.projectlombok:lombok:$lombokVersion")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
 dependencyManagement {

--- a/starter/src/main/java/studio/one/application/forums/cache/TopicPostListCacheResolver.java
+++ b/starter/src/main/java/studio/one/application/forums/cache/TopicPostListCacheResolver.java
@@ -48,13 +48,33 @@ public class TopicPostListCacheResolver implements CacheResolver {
     @Override
     public Collection<? extends Cache> resolveCaches(CacheOperationInvocationContext<?> context) {
         Object[] args = context.getArgs();
-        if (args.length == 0 || args[0] == null) {
+        if (args.length < 2) {
             return Collections.emptyList();
         }
-        Long topicId = (Long) args[0];
+        Long topicId = toLong(args[1]);
+        if (topicId == null) {
+            return Collections.emptyList();
+        }
         String cacheName = CacheNames.Post.listCacheName(topicId);
         Cache cache = resolveCache(cacheName);
         return cache == null ? Collections.emptyList() : Collections.singletonList(cache);
+    }
+
+    private Long toLong(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).longValue();
+        }
+        if (value instanceof String) {
+            try {
+                return Long.parseLong((String) value);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
     }
 
     private Cache resolveCache(String cacheName) {

--- a/starter/src/test/java/studio/one/application/forums/cache/TopicPostListCacheResolverTest.java
+++ b/starter/src/test/java/studio/one/application/forums/cache/TopicPostListCacheResolverTest.java
@@ -1,0 +1,83 @@
+package studio.one.application.forums.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.interceptor.CacheOperationInvocationContext;
+import studio.one.application.forums.constant.CacheNames;
+
+class TopicPostListCacheResolverTest {
+
+    @Test
+    void resolveCaches_usesSecondArgumentAsTopicId() {
+        CacheManager cacheManager = mock(CacheManager.class);
+        Cache cache = mock(Cache.class);
+        when(cache.getName()).thenReturn(CacheNames.Post.listCacheName(123L));
+        when(cacheManager.getCache(CacheNames.Post.listCacheName(123L))).thenReturn(cache);
+        TopicPostListCacheResolver resolver = new TopicPostListCacheResolver(
+            cacheManager,
+            true,
+            Duration.ofSeconds(60),
+            100,
+            false
+        );
+
+        CacheOperationInvocationContext<?> context = mock(CacheOperationInvocationContext.class);
+        when(context.getArgs()).thenReturn(new Object[] { "notice", 123L });
+
+        Collection<? extends Cache> caches = resolver.resolveCaches(context);
+
+        assertThat(caches).hasSize(1);
+        assertThat(caches.iterator().next().getName()).isEqualTo(CacheNames.Post.listCacheName(123L));
+    }
+
+    @Test
+    void resolveCaches_acceptsStringTopicId() {
+        CacheManager cacheManager = mock(CacheManager.class);
+        Cache cache = mock(Cache.class);
+        when(cache.getName()).thenReturn(CacheNames.Post.listCacheName(123L));
+        when(cacheManager.getCache(CacheNames.Post.listCacheName(123L))).thenReturn(cache);
+        TopicPostListCacheResolver resolver = new TopicPostListCacheResolver(
+            cacheManager,
+            true,
+            Duration.ofSeconds(60),
+            100,
+            false
+        );
+
+        CacheOperationInvocationContext<?> context = mock(CacheOperationInvocationContext.class);
+        when(context.getArgs()).thenReturn(new Object[] { "notice", "123" });
+
+        Collection<? extends Cache> caches = resolver.resolveCaches(context);
+
+        assertThat(caches).hasSize(1);
+        assertThat(caches.iterator().next().getName()).isEqualTo(CacheNames.Post.listCacheName(123L));
+    }
+
+    @Test
+    void resolveCaches_returnsEmptyWhenArgsDoNotContainValidTopicId() {
+        CacheManager cacheManager = mock(CacheManager.class);
+        TopicPostListCacheResolver resolver = new TopicPostListCacheResolver(
+            cacheManager,
+            true,
+            Duration.ofSeconds(60),
+            100,
+            false
+        );
+
+        CacheOperationInvocationContext<?> tooShort = mock(CacheOperationInvocationContext.class);
+        when(tooShort.getArgs()).thenReturn(new Object[] { "notice" });
+
+        CacheOperationInvocationContext<?> invalid = mock(CacheOperationInvocationContext.class);
+        when(invalid.getArgs()).thenReturn(new Object[] { "notice", "abc" });
+
+        assertThat(resolver.resolveCaches(tooShort)).isEmpty();
+        assertThat(resolver.resolveCaches(invalid)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- What changed:
  - Fixed `TopicPostListCacheResolver` to read `topicId` from argument index `1` (method signature: `listPosts(String forumSlug, Long topicId, ...)`).
  - Added safe `toLong(Object)` conversion (`Number`/numeric `String`) and fail-safe empty cache fallback on invalid values.
  - Added `starter` unit tests for resolver behavior across valid and invalid argument shapes.
- Why:
  - Production error `ClassCastException: String cannot be cast to Long` occurred in post list cache resolution.

## Related Issues
- Closes #3
- Related #3

## Change Scope
- [ ] API contract
- [x] Business logic
- [ ] DB schema/query
- [ ] Security/permission
- [x] Docs/runbook

## Security Impact
- Risk:
  - No direct security impact; this is a stability/availability fix for read path caching.
- Mitigation:
  - Resolver now validates argument shape/type before cache name generation.

## Validation
- [x] `./gradlew -q compileJava`
- [x] `./gradlew -q :starter:test`
- Additional checks:
  - Added tests in `starter/src/test/java/studio/one/application/forums/cache/TopicPostListCacheResolverTest.java`.

## Deployment Notes
- Migration/ordering:
  - None.
- Rollback plan:
  - Revert commit `de3162f`.
- Post-deploy checks:
  - Verify `GET /api/forums/{forumSlug}/topics/{topicId}/posts` returns 200 and no longer logs `ClassCastException`.